### PR TITLE
copy the real resolv.conf file

### DIFF
--- a/menhera.sh
+++ b/menhera.sh
@@ -138,7 +138,7 @@ menhera::install_software() {
 
 menhera::copy_config() {
     echo "Copying important config into new rootfs..."
-    ! cp -ax "${OLDROOT}/etc/resolv.conf" "${NEWROOT}/etc"
+    ! cp -axL "${OLDROOT}/etc/resolv.conf" "${NEWROOT}/etc"
     ! cp -axr "${OLDROOT}/etc/ssh" "${NEWROOT}/etc"
     ! cp -ax "${OLDROOT}/etc/"{passwd,shadow} "${NEWROOT}/etc"
     ! cp -axr "${OLDROOT}/root/.ssh" "${NEWROOT}/root"


### PR DESCRIPTION
Hello,

In some system (Vultr Debian 10), the `/etc/resolv.conf` is a soft link to somewhere on the system.

```
# ls -al /etc/resolv.conf 
lrwxrwxrwx 1 root root 31 Feb 15 08:34 /etc/resolv.conf -> /etc/resolvconf/run/resolv.conf
```

I am adding `-L` param to cp which will copy the source file of the symbolic link.

```
       -L, --dereference
              always follow symbolic links in SOURCE
```
