### PR TITLE
fix: use list-units not list-unit-files

### DIFF
--- a/menhera.sh
+++ b/menhera.sh
@@ -33,7 +33,7 @@ EOF
 }
 
 menhera::__compat_sshd_name() {
-    if systemctl list-unit-files sshd.service >/dev/null; then
+    if systemctl list-units ssh.service | grep "0 loaded" >/dev/null; then
         echo sshd
     else
         echo ssh


### PR DESCRIPTION
systemd 在根目录切换到新的 rootfs 并 reload 后，list-unit-files 展示的内容是新 rootfs 提供的

另一种可能的解决方式是停止 sshd 后daemon-reload

fix #18